### PR TITLE
Fix bug in ProgressesController

### DIFF
--- a/app/controllers/admin/progresses_controller.rb
+++ b/app/controllers/admin/progresses_controller.rb
@@ -15,7 +15,10 @@ module Admin
            end
            format.html { redirect_to admin_progresses_path, notice: 'Progress was successfully created.' }
          else
-           format.html { render action: 'new' }
+           format.html {
+             render action: 'new',
+             locals: { page: Administrate::Page::Form.new(dashboard, resource_class.new) }
+           }
          end
        end
      end


### PR DESCRIPTION
## Problem

The `progresses#new` view requires the local variable `page` to be defined.
It is usually passed to the view by `Administrate::ApplicationController#create`
(see [these lines of code](https://github.com/thoughtbot/administrate/blob/fb6cdb0777599c81ba96fbbd3162fc1e024d50e6/app/controllers/administrate/application_controller.rb#L46-L48)),
but when we overwrote the `#create` method, the new call to `render`
didn't pass in the `page` local variable.
## Solution

Copy over the local variable from `Administrate::ApplicationController#create`,
so the view has the local variables it needs to render correctly.
